### PR TITLE
Update Get-EnterprisePKIHealthStatus.ps1

### DIFF
--- a/PSPKI/Server/Get-EnterprisePKIHealthStatus.ps1
+++ b/PSPKI/Server/Get-EnterprisePKIHealthStatus.ps1
@@ -623,8 +623,8 @@ namespace PKI.EnterprisePKI {
 						Write-Warning "Only Enterprise CAs are supported by this parameterset."
 						return
 					}
-					Write-Verbose ("=" * 20) $CA.DisplayName ("=" * 20)
-					Write-Debug ("=" * 20) $CA.DisplayName ("=" * 20)
+					Write-Verbose $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))
+					Write-Debug $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))
 					Write-Debug "$($CA.DisplayName): retrieving CA Exchange certificate."
 					$xchg = $CA.GetCAExchangeCertificate()
 					__validateSinglePath $xchg

--- a/PSPKI/Server/Get-EnterprisePKIHealthStatus.ps1
+++ b/PSPKI/Server/Get-EnterprisePKIHealthStatus.ps1
@@ -623,8 +623,8 @@ namespace PKI.EnterprisePKI {
 						Write-Warning "Only Enterprise CAs are supported by this parameterset."
 						return
 					}
-					Write-Verbose $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))
-					Write-Debug $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))
+					Write-Verbose ("{0} {1} {0}" -f ('=' * 20), $CA.DisplayName)
+					Write-Debug ("{0} {1} {0}" -f ('=' * 20), $CA.DisplayName)
 					Write-Debug "$($CA.DisplayName): retrieving CA Exchange certificate."
 					$xchg = $CA.GetCAExchangeCertificate()
 					__validateSinglePath $xchg


### PR DESCRIPTION
When I use this command on Windows Server 2016 it gives me two exceptions, both saying "A positional parameter cannot be found that accepts argument". The exceptions happen on line 626 and 627:

Line 626: Write-Verbose ("=" * 20) $CA.DisplayName ("=" * 20)
Line 627: Write-Debug ("=" * 20) $CA.DisplayName ("=" * 20)

To fix, I suggest change it to:

Line 626: Write-Verbose $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))
Line 627: Write-Debug $(('=' * 20)+' '+$CA.DisplayName+' '+('=' * 20))